### PR TITLE
[Fix] CircleCIでdeployがtestより先に行われてしまうことを防ぐ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ workflows:
             branches:
               only:
                 - master
-                - feature/*
+                - /feature.*/
       - deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ workflows:
                 - master
                 - feature/*
       - deploy:
+          requires:
+            - test
           filters:
             branches:
               only: master


### PR DESCRIPTION
- test jobが成功 && master branchの時だけにしたい