### PR TITLE
[Add] database.ymlにHeroku用の情報を記述

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -15,3 +15,10 @@ development:
 test:
   <<: *mariadb_default
   database: dice_test
+
+production:
+  <<: *mariadb_default
+  host: <%= ENV["DB_HOST"] %>
+  database: <%= ENV["DB_DATABASE"] %>
+  username: <%= ENV["DB_USERNAME"] %>
+  password: <%= ENV["DB_PASSWORD"] %>


### PR DESCRIPTION
```
Herokuでクレジット登録
$ heroku addons:create cleardb:ignite
$ heroku config | grep CLEARDB_DATABASE_URL
CLEARDB_DATABASE_URL: mysql://USERNAME:PASSWORD@HOST/DATABASE?reconnect=true
$ heroku config:set hogehoge=fugafuga
```